### PR TITLE
Added DateTime wo TZ mapping

### DIFF
--- a/JSqlServerBulkInsert/src/main/java/de/bytefish/jsqlserverbulkinsert/mapping/AbstractMapping.java
+++ b/JSqlServerBulkInsert/src/main/java/de/bytefish/jsqlserverbulkinsert/mapping/AbstractMapping.java
@@ -13,6 +13,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Types;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.util.ArrayList;
@@ -92,6 +93,10 @@ public abstract class AbstractMapping<TEntity> {
 
     protected void mapDate(String columnName, Func2<TEntity, LocalDate> propertyGetter) {
         addColumn(columnName, Types.DATE, propertyGetter);
+    }
+
+    protected void mapDateTime(String columnName, Func2<TEntity, LocalDateTime> propertyGetter) {
+        addColumn(columnName, Types.TIMESTAMP, propertyGetter);
     }
 
     protected void mapDouble(String columnName, Func2<TEntity, Double> propertyGetter)


### PR DESCRIPTION
Added mapping for DateTime without timezone. This is the datetime2 type in Sql Server, corresponding to Types.TIMESTAMP {java.sql.Timestamp), as specified here https://docs.microsoft.com/en-us/sql/connect/jdbc/using-basic-data-types?view=sql-server-2017