### PR TITLE
Add AutoIncrement for SmallInt, Int, and BigInt

### DIFF
--- a/JSqlServerBulkInsert/src/main/java/de/bytefish/jsqlserverbulkinsert/mapping/AbstractMapping.java
+++ b/JSqlServerBulkInsert/src/main/java/de/bytefish/jsqlserverbulkinsert/mapping/AbstractMapping.java
@@ -87,8 +87,8 @@ public abstract class AbstractMapping<TEntity> {
         addColumn(columnName, Types.BIGINT, wrapper);
     }
 
-    protected void mapBigIntLong(String columnName, Func2<TEntity, Long> propertyGetter) {
-        addColumn(columnName, Types.BIGINT, propertyGetter);
+    protected void mapBigIntLong(String columnName, Func2<TEntity, Long> propertyGetter, boolean isAutoIncrement) {
+        addColumn(columnName, Types.BIGINT, isAutoIncrement, propertyGetter);
     }
 
     protected void mapDate(String columnName, Func2<TEntity, LocalDate> propertyGetter) {
@@ -104,14 +104,14 @@ public abstract class AbstractMapping<TEntity> {
         addColumn(columnName, Types.DOUBLE, propertyGetter);
     }
 
-    protected void mapInt(String columnName, Func2<TEntity, Integer> propertyGetter)
+    protected void mapInt(String columnName, Func2<TEntity, Integer> propertyGetter, boolean isAutoIncrement)
     {
-        addColumn(columnName, Types.INTEGER, propertyGetter);
+        addColumn(columnName, Types.INTEGER, isAutoIncrement, propertyGetter);
     }
 
-    protected void mapSmallInt(String columnName, Func2<TEntity, Short> propertyGetter)
+    protected void mapSmallInt(String columnName, Func2<TEntity, Short> propertyGetter, boolean isAutoIncrement)
     {
-        addColumn(columnName, Types.SMALLINT, propertyGetter);
+        addColumn(columnName, Types.SMALLINT, isAutoIncrement, propertyGetter);
     }
 
     protected void mapTinyInt(String columnName, Func2<TEntity, Byte> propertyGetter)
@@ -135,7 +135,7 @@ public abstract class AbstractMapping<TEntity> {
         addColumn(columnName, Types.VARBINARY, maxLength, 0, false, propertyGetter);
     }
 
-    private void addColumn(String name, int type, boolean isAutoIncrement, Func2<TEntity, Object> propertyGetter)
+    private <TProperty> void addColumn(String name, int type, boolean isAutoIncrement, Func2<TEntity, TProperty> propertyGetter)
     {
         // Create the current Column Meta Data:
         ColumnMetaData columnMetaData = new ColumnMetaData(name, type, 0, 0, isAutoIncrement);

--- a/JSqlServerBulkInsert/src/test/java/de/bytefish/jsqlserverbulkinsert/test/mapping/AutoIncrementIntMappingTest.java
+++ b/JSqlServerBulkInsert/src/test/java/de/bytefish/jsqlserverbulkinsert/test/mapping/AutoIncrementIntMappingTest.java
@@ -30,8 +30,8 @@ public class AutoIncrementIntMappingTest extends TransactionalTestBase {
         public IntegerEntityMapping() {
             super("dbo", "UnitTest");
 
-            mapInt("PK_ID", x -> null);
-            mapInt("IntegerValue", IntegerEntity::getValue);
+            mapInt("PK_ID", x -> null, false);
+            mapInt("IntegerValue", IntegerEntity::getValue, false);
         }
 
     }

--- a/JSqlServerBulkInsert/src/test/java/de/bytefish/jsqlserverbulkinsert/test/mapping/BigIntegerLongMappingTest.java
+++ b/JSqlServerBulkInsert/src/test/java/de/bytefish/jsqlserverbulkinsert/test/mapping/BigIntegerLongMappingTest.java
@@ -31,7 +31,7 @@ public class BigIntegerLongMappingTest extends TransactionalTestBase {
         public BigIntegerMapping() {
             super("dbo", "UnitTest");
 
-            mapBigIntLong("BigIntegerValue", BigIntegerEntity::getValue);
+            mapBigIntLong("BigIntegerValue", BigIntegerEntity::getValue, false);
         }
 
     }

--- a/JSqlServerBulkInsert/src/test/java/de/bytefish/jsqlserverbulkinsert/test/mapping/IntMappingTest.java
+++ b/JSqlServerBulkInsert/src/test/java/de/bytefish/jsqlserverbulkinsert/test/mapping/IntMappingTest.java
@@ -29,7 +29,7 @@ public class IntMappingTest extends TransactionalTestBase {
         public IntegerEntityMapping() {
             super("dbo", "UnitTest");
 
-            mapInt("IntegerValue", IntegerEntity::getValue);
+            mapInt("IntegerValue", IntegerEntity::getValue, false);
         }
 
     }

--- a/JSqlServerBulkInsert/src/test/java/de/bytefish/jsqlserverbulkinsert/test/mapping/SmallIntMappingTest.java
+++ b/JSqlServerBulkInsert/src/test/java/de/bytefish/jsqlserverbulkinsert/test/mapping/SmallIntMappingTest.java
@@ -29,7 +29,7 @@ public class SmallIntMappingTest extends TransactionalTestBase {
         public ShortEntityMapping() {
             super("dbo", "UnitTest");
 
-            mapSmallInt("ShortValue", ShortEntity::getValue);
+            mapSmallInt("ShortValue", ShortEntity::getValue, false);
         }
 
     }


### PR DESCRIPTION
- in order to support Identity columns in SQL Server